### PR TITLE
Emit the Active property instead of the Elements

### DIFF
--- a/LongoMatch.GUI/Gui/TreeView/EventsFilterTreeView.cs
+++ b/LongoMatch.GUI/Gui/TreeView/EventsFilterTreeView.cs
@@ -58,7 +58,7 @@ namespace LongoMatch.Gui.Component
 			predicate.IgnoreEvents = true;
 			UpdateActiveFilter (iter, active);
 			predicate.IgnoreEvents = false;
-			predicate.EmitPredicateChanged ();
+			predicate.EmitActiveChanged ();
 		}
 
 		private void UpdateActiveFilter (TreeIter iter, bool active)


### PR DESCRIPTION
Emitting the Elements collection was causing it to refresh the filter checkboxes