### PR TITLE
VAS-98 - Move StyleConf values to its own classes under Resources namespace

### DIFF
--- a/LongoMatch.Core/Store/Templates/LMDashboard.cs
+++ b/LongoMatch.Core/Store/Templates/LMDashboard.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using VAS.Core;
 using VAS.Core.Common;
 using VAS.Core.Interfaces;
+using VAS.Core.Resources.Styles;
 using VAS.Core.Store;
 using VAS.Core.Store.Templates;
 
@@ -82,13 +83,13 @@ namespace LongoMatch.Core.Store.Templates
 
 			scoreButton = new ScoreButton {
 				Position = new Point (10 + (10 + CAT_WIDTH) * 4, 10),
-				BackgroundColor = StyleConf.ButtonScoreColor,
+				BackgroundColor = Colors.ButtonScoreColor,
 				Score = new Score (Catalog.GetString ("Free play goal"), 1),
 			};
 			template.List.Add (scoreButton);
 
 			scoreButton = new ScoreButton {
-				BackgroundColor = StyleConf.ButtonScoreColor,
+				BackgroundColor = Colors.ButtonScoreColor,
 				Position = new Point (10 + (10 + CAT_WIDTH) * 5, 10),
 				Score = new Score (Catalog.GetString ("Penalty goal"), 1),
 			};
@@ -111,7 +112,7 @@ namespace LongoMatch.Core.Store.Templates
 		{
 			AnalysisEventButton button;
 			AnalysisEventType evtype;
-			Color c = StyleConf.ButtonEventColor;
+			Color c = Colors.ButtonEventColor;
 			HotKey h = new HotKey ();
 
 			evtype = new AnalysisEventType {

--- a/LongoMatch.Core/Store/Templates/LMTeam.cs
+++ b/LongoMatch.Core/Store/Templates/LMTeam.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using VAS.Core;
 using VAS.Core.Common;
+using VAS.Core.Resources;
 using VAS.Core.Serialization;
 using VAS.Core.Store;
 using VAS.Core.Store.Templates;
@@ -41,7 +42,7 @@ namespace LongoMatch.Core.Store.Templates
 			TeamName = Catalog.GetString ("Team");
 			FormationStr = "1-4-3-3";
 			try {
-				Shield = App.Current.ResourcesLocator.LoadImage (StyleConf.DefaultShield);
+				Shield = App.Current.ResourcesLocator.LoadIcon (Icons.DefaultShield);
 			} catch {
 				/* Ignore for unit tests */
 			}

--- a/LongoMatch.Drawing/CanvasObjects/Dashboard/CardView.cs
+++ b/LongoMatch.Drawing/CanvasObjects/Dashboard/CardView.cs
@@ -22,6 +22,7 @@ using VAS.Core.Common;
 using VAS.Core.Interfaces.Drawing;
 using VAS.Core.Interfaces.MVVMC;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.Drawing.CanvasObjects.Dashboard;
 
 namespace LongoMatch.Drawing.CanvasObjects.Dashboard
@@ -54,7 +55,7 @@ namespace LongoMatch.Drawing.CanvasObjects.Dashboard
 			tk.Begin ();
 
 			if (Active) {
-				tk.LineWidth = StyleConf.ButtonLineWidth;
+				tk.LineWidth = Sizes.ButtonLineWidth;
 				tk.StrokeColor = BackgroundColor;
 				tk.FillColor = TextColor;
 			} else {
@@ -81,7 +82,7 @@ namespace LongoMatch.Drawing.CanvasObjects.Dashboard
 
 			/* Draw header */
 			tk.LineWidth = 2;
-			tk.FontSize = StyleConf.ButtonNameFontSize;
+			tk.FontSize = Sizes.ButtonNameFontSize;
 			tk.FontWeight = FontWeight.Light;
 			tk.FontAlignment = FontAlignment.Center;
 			if (Recording) {

--- a/LongoMatch.Drawing/CanvasObjects/Dashboard/ScoreView.cs
+++ b/LongoMatch.Drawing/CanvasObjects/Dashboard/ScoreView.cs
@@ -20,6 +20,7 @@ using VAS.Core;
 using VAS.Core.Common;
 using VAS.Core.Interfaces.MVVMC;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources;
 using VAS.Drawing.CanvasObjects.Dashboard;
 
 namespace LongoMatch.Drawing.CanvasObjects.Dashboard
@@ -31,7 +32,7 @@ namespace LongoMatch.Drawing.CanvasObjects.Dashboard
 
 		static ScoreView ()
 		{
-			iconImage = App.Current.ResourcesLocator.LoadImage (StyleConf.ButtonScoreIcon);
+			iconImage = App.Current.ResourcesLocator.LoadImage (Images.ButtonScore);
 		}
 
 		public ScoreButtonVM ViewModel {

--- a/LongoMatch.Drawing/CanvasObjects/Teams/BenchObject.cs
+++ b/LongoMatch.Drawing/CanvasObjects/Teams/BenchObject.cs
@@ -18,6 +18,7 @@
 using System.Collections.Generic;
 using VAS.Core.Common;
 using VAS.Core.Interfaces.Drawing;
+using VAS.Core.Resources.Styles;
 using VAS.Core.Store.Drawables;
 using VAS.Drawing.CanvasObjects;
 using VASDrawing = VAS.Drawing;
@@ -93,7 +94,7 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 			tk.Begin ();
 			tk.TranslateAndScale (Position, new Point (1, 1));
 			tk.LineStyle = LineStyle.Dashed;
-			tk.LineWidth = App.Current.Style.BenchLineWidth;
+			tk.LineWidth = Sizes.BenchLineWidth;
 			tk.StrokeColor = App.Current.Style.ThemeContrastDisabled;
 			tk.FillColor = null;
 			tk.DrawRectangle (new Point (0, 0), Width, Height);

--- a/LongoMatch.Drawing/CanvasObjects/Teams/LMPlayerView.cs
+++ b/LongoMatch.Drawing/CanvasObjects/Teams/LMPlayerView.cs
@@ -20,6 +20,8 @@ using LongoMatch.Core.ViewModel;
 using VAS.Core.Common;
 using VAS.Core.Interfaces.Drawing;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources;
+using VAS.Core.Resources.Styles;
 using VAS.Drawing.CanvasObjects.Teams;
 
 namespace LongoMatch.Drawing.CanvasObjects.Teams
@@ -32,8 +34,8 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 
 		static LMPlayerView ()
 		{
-			ArrowOut = App.Current.DrawingToolkit.CreateSurfaceFromResource (StyleConf.PlayerArrowOut);
-			ArrowIn = App.Current.DrawingToolkit.CreateSurfaceFromResource (StyleConf.PlayerArrowIn);
+			ArrowOut = App.Current.DrawingToolkit.CreateSurfaceFromResource (Images.PlayerArrowOut);
+			ArrowIn = App.Current.DrawingToolkit.CreateSurfaceFromResource (Images.PlayerArrowIn);
 		}
 
 		public LMPlayerView ()
@@ -84,7 +86,7 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 				return;
 
 			zero = new Point (0, 0);
-			size = StyleConf.PlayerSize;
+			size = Sizes.PlayerSize;
 			scale = (double)Width / size;
 
 			if (Team == TeamType.LOCAL) {
@@ -106,17 +108,17 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 			/* Background */
 			tk.FillColor = App.Current.Style.ThemeBase;
 			tk.LineWidth = 0;
-			tk.DrawRectangle (zero, StyleConf.PlayerSize, StyleConf.PlayerSize);
+			tk.DrawRectangle (zero, Sizes.PlayerSize, Sizes.PlayerSize);
 
 			/* Image */
 			if (Player.Photo != null) {
 				tk.DrawImage (zero, size, size, Player.Photo, ScaleMode.AspectFit);
 			} else {
-				tk.DrawSurface (zero, StyleConf.PlayerSize, StyleConf.PlayerSize, DefaultPhoto, ScaleMode.AspectFit);
+				tk.DrawSurface (zero, Sizes.PlayerSize, Sizes.PlayerSize, DefaultPhoto, ScaleMode.AspectFit);
 			}
 
 			/* Bottom line */
-			p = new Point (0, size - StyleConf.PlayerLineWidth);
+			p = new Point (0, size - Sizes.PlayerLineWidth);
 			tk.FillColor = Color;
 			tk.DrawRectangle (p, size, 3);
 
@@ -130,15 +132,15 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 				} else {
 					arrow = arrowin;
 				}
-				ap = new Point (StyleConf.PlayerArrowX, StyleConf.PlayerArrowY);
-				tk.DrawRectangle (ap, StyleConf.PlayerArrowSize, StyleConf.PlayerArrowSize);
+				ap = new Point (Sizes.PlayerArrowX, Sizes.PlayerArrowY);
+				tk.DrawRectangle (ap, Sizes.PlayerArrowSize, Sizes.PlayerArrowSize);
 				tk.DrawSurface (arrow, ap);
 			}
 
 			/* Draw number */
-			p = new Point (StyleConf.PlayerNumberX, StyleConf.PlayerNumberY);
+			p = new Point (Sizes.PlayerNumberX, Sizes.PlayerNumberY);
 			tk.FillColor = Color;
-			tk.DrawRectangle (p, StyleConf.PlayerNumberSize, StyleConf.PlayerNumberSize);
+			tk.DrawRectangle (p, Sizes.PlayerNumberSize, Sizes.PlayerNumberSize);
 
 			tk.FillColor = Color.White;
 			tk.StrokeColor = Color.White;
@@ -149,7 +151,7 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 			} else {
 				tk.FontSize = 16;
 			}
-			tk.DrawText (p, StyleConf.PlayerNumberSize, StyleConf.PlayerNumberSize,
+			tk.DrawText (p, Sizes.PlayerNumberSize, Sizes.PlayerNumberSize,
 						 ViewModel.Number.ToString ());
 
 			if (Player.Tagged && !SubstitutionMode) {

--- a/LongoMatch.Drawing/CanvasObjects/Teams/LMPlayersTaggerView.cs
+++ b/LongoMatch.Drawing/CanvasObjects/Teams/LMPlayersTaggerView.cs
@@ -29,6 +29,8 @@ using LongoMatch.Services.ViewModel;
 using VAS.Core;
 using VAS.Core.Common;
 using VAS.Core.Interfaces.Drawing;
+using VAS.Core.Resources;
+using VAS.Core.Resources.Styles;
 using VAS.Core.Store;
 using VAS.Core.Store.Drawables;
 using VAS.Drawing.CanvasObjects;
@@ -178,7 +180,7 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 				homePlayers.AddRange (homeBenchPlayers);
 				homeF = homeTeam.Formation;
 				if (ViewModel.HomeTeam.Icon == null) {
-					homeButton.BackgroundImage = App.Current.ResourcesLocator.LoadImage (StyleConf.DefaultShield);
+					homeButton.BackgroundImage = App.Current.ResourcesLocator.LoadIcon (Icons.DefaultShield);
 				} else {
 					homeButton.BackgroundImage = ViewModel.HomeTeam.Icon;
 				}
@@ -193,7 +195,7 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 				awayPlayers.AddRange (awayBenchPlayers);
 				awayF = awayTeam.Formation;
 				if (ViewModel.AwayTeam.Icon == null) {
-					awayButton.BackgroundImage = App.Current.ResourcesLocator.LoadImage (StyleConf.DefaultShield);
+					awayButton.BackgroundImage = App.Current.ResourcesLocator.LoadIcon (Icons.DefaultShield);
 				} else {
 					awayButton.BackgroundImage = ViewModel.AwayTeam.Icon;
 				}
@@ -210,7 +212,7 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 			awayBench.BenchPlayers = awayBenchPlayers;
 			homeBench.Height = awayBench.Height = field.Height;
 
-			border = App.Current.Style.TeamTaggerBenchBorder;
+			border = Sizes.TeamTaggerBenchBorder;
 			if (homeTeam == null || awayTeam == null) {
 				if (homeTeam != null) {
 					homeBench.Position = new Point (border, 0);
@@ -297,9 +299,9 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 		void LoadSubsButtons ()
 		{
 			subPlayers = new ButtonObject ();
-			subPlayers.BackgroundImageActive = App.Current.ResourcesLocator.LoadImage (StyleConf.SubsUnlock);
+			subPlayers.BackgroundImageActive = App.Current.ResourcesLocator.LoadIcon (Icons.SubsUnlock);
 			subPlayers.BackgroundColorActive = App.Current.Style.ScreenBase;
-			subPlayers.BackgroundImage = App.Current.ResourcesLocator.LoadImage (StyleConf.SubsLock);
+			subPlayers.BackgroundImage = App.Current.ResourcesLocator.LoadIcon (Icons.SubsLock);
 			subPlayers.Toggle = true;
 			subPlayers.ClickedEvent += HandleSubsClicked;
 			subPlayers.RedrawEvent += (co, area) => EmitRedrawEvent (subPlayers, area);
@@ -476,7 +478,7 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 			/* Compute how we should scale and translate to fit the widget
 			 * in the designated area */
 			width = homeBench.Width * NTeams + field.Width +
-			2 * NTeams * App.Current.Style.TeamTaggerBenchBorder;
+			2 * NTeams * Sizes.TeamTaggerBenchBorder;
 			height = field.Height;
 			Image.ScaleFactor ((int)width, (int)height, (int)Width,
 				(int)Height - BUTTONS_HEIGHT, ScaleMode.AspectFit,
@@ -495,12 +497,12 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 			}
 			if (homeButton.Visible) {
 				/* Draw local team button */
-				double x = Position.X + App.Current.Style.TeamTaggerBenchBorder * scaleX + offset.X;
+				double x = Position.X + Sizes.TeamTaggerBenchBorder * scaleX + offset.X;
 				homeButton.Position = new Point (x, offset.Y - homeButton.Height);
 				homeButton.Draw (tk, area);
 			}
 			if (awayButton.Visible) {
-				double x = (Position.X + Width - offset.X - App.Current.Style.TeamTaggerBenchBorder * scaleX) - awayButton.Width;
+				double x = (Position.X + Width - offset.X - Sizes.TeamTaggerBenchBorder * scaleX) - awayButton.Width;
 				awayButton.Position = new Point (x, offset.Y - awayButton.Height);
 				awayButton.Draw (tk, area);
 			}

--- a/LongoMatch.Drawing/CanvasObjects/Timeline/PeriodsTimelineView.cs
+++ b/LongoMatch.Drawing/CanvasObjects/Timeline/PeriodsTimelineView.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using VAS.Core.Common;
 using VAS.Core.Interfaces.Drawing;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.Core.Store;
 using VAS.Core.ViewModel;
 using VAS.Drawing.CanvasObjects.Timeline;
@@ -87,10 +88,10 @@ namespace LongoMatch.Drawing.CanvasObjects.Timeline
 
 			if (ShowLine) {
 				// We want the background line and overlay to use the same starting point although they have different sizes.
-				double linepos = OffsetY + Height / 2 + StyleConf.TimelineLineSize / 2;
+				double linepos = OffsetY + Height / 2 + Sizes.TimelineLineSize / 2;
 				tk.FillColor = App.Current.Style.ThemeBase;
 				tk.StrokeColor = App.Current.Style.ThemeBase;
-				tk.LineWidth = StyleConf.TimelineBackgroundLineSize;
+				tk.LineWidth = Sizes.TimelineBackgroundLineSize;
 				tk.DrawLine (new Point (0, linepos),
 							 new Point (Width, linepos));
 			}

--- a/LongoMatch.Drawing/PlayslistCellRenderer.cs
+++ b/LongoMatch.Drawing/PlayslistCellRenderer.cs
@@ -23,6 +23,8 @@ using VAS.Core.Common;
 using VAS.Core.Interfaces;
 using VAS.Core.Interfaces.Drawing;
 using VAS.Core.Interfaces.MVVMC;
+using VAS.Core.Resources;
+using VAS.Core.Resources.Styles;
 using VAS.Core.Store;
 using VAS.Core.Store.Playlists;
 using VAS.Core.Store.Templates;
@@ -52,11 +54,11 @@ namespace LongoMatch.Drawing
 		//RiftAnalyst, try to reuse the code.
 		static PlayslistCellRenderer ()
 		{
-			PlayIcon = App.Current.DrawingToolkit.CreateSurfaceFromResource (StyleConf.PlayButton, false);
-			BtnNormalBackground = App.Current.DrawingToolkit.CreateSurfaceFromResource (StyleConf.NormalButtonNormalTheme, false);
-			BtnNormalBackgroundPrelight = App.Current.DrawingToolkit.CreateSurfaceFromResource (StyleConf.NormalButtonPrelightTheme, false);
-			BtnNormalBackgroundActive = App.Current.DrawingToolkit.CreateSurfaceFromResource (StyleConf.NormalButtonActiveTheme, false);
-			BtnNormalBackgroundInsensitive = App.Current.DrawingToolkit.CreateSurfaceFromResource (StyleConf.NormalButtonInsensititveTheme, false);
+			PlayIcon = App.Current.DrawingToolkit.CreateSurfaceFromIcon (Icons.PlayButton, false);
+			BtnNormalBackground = App.Current.DrawingToolkit.CreateSurfaceFromResource (Themes.NormalButtonNormalTheme, false);
+			BtnNormalBackgroundPrelight = App.Current.DrawingToolkit.CreateSurfaceFromResource (Themes.NormalButtonPrelightTheme, false);
+			BtnNormalBackgroundActive = App.Current.DrawingToolkit.CreateSurfaceFromResource (Themes.NormalButtonActiveTheme, false);
+			BtnNormalBackgroundInsensitive = App.Current.DrawingToolkit.CreateSurfaceFromResource (Themes.NormalButtonInsensititveTheme, false);
 		}
 
 		/// <summary>
@@ -120,14 +122,14 @@ namespace LongoMatch.Drawing
 			// FIXME: Remove it with everything is ported to MVVM
 			po.Player = new LMPlayerVM { Model = p };
 			po.Position = imagePoint;
-			po.Size = StyleConf.ListImageWidth - 2;
+			po.Size = Sizes.ListImageWidth - 2;
 			po.Draw (tk, null);
 			po.Dispose ();
 		}
 
 		static void RenderTeam (IDrawingToolkit tk, Team team, Point imagePoint)
 		{
-			tk.DrawImage (imagePoint, StyleConf.ListImageWidth, StyleConf.ListImageWidth, team.Shield,
+			tk.DrawImage (imagePoint, Sizes.ListImageWidth, Sizes.ListImageWidth, team.Shield,
 				ScaleMode.AspectFit);
 		}
 
@@ -137,37 +139,37 @@ namespace LongoMatch.Drawing
 			Point arrowY;
 			ISurface arrow;
 
-			countX1 = cellArea.Start.X + StyleConf.ListRowSeparator * 2 + StyleConf.ListCountRadio;
-			countX2 = countX1 + StyleConf.ListCountWidth;
+			countX1 = cellArea.Start.X + Sizes.ListRowSeparator * 2 + Sizes.ListCountRadio;
+			countX2 = countX1 + Sizes.ListCountWidth;
 			countYC = backgroundArea.Start.Y + backgroundArea.Height / 2;
-			countY = countYC - StyleConf.ListCountRadio;
+			countY = countYC - Sizes.ListCountRadio;
 			if (count > 0) {
 				if (!isExpanded) {
 					if (ArrowRight == null) {
-						ArrowRight = App.Current.DrawingToolkit.CreateSurfaceFromResource (StyleConf.ListArrowRightPath, false);
+						ArrowRight = App.Current.DrawingToolkit.CreateSurfaceFromIcon (Icons.ListArrowRightPath, false);
 					}
 					arrow = ArrowRight;
 				} else {
 					if (ArrowDown == null) {
-						ArrowDown = App.Current.DrawingToolkit.CreateSurfaceFromResource (StyleConf.ListArrowDownPath, false);
+						ArrowDown = App.Current.DrawingToolkit.CreateSurfaceFromIcon (Icons.ListArrowDownPath, false);
 					}
 					arrow = ArrowDown;
 				}
 				arrowY = new Point (cellArea.Start.X + 1, cellArea.Start.Y + cellArea.Height / 2 - arrow.Height / 2);
-				tk.DrawSurface (arrowY, StyleConf.ListArrowRightWidth, StyleConf.ListArrowRightHeight, arrow, ScaleMode.AspectFit);
+				tk.DrawSurface (arrowY, Sizes.ListArrowRightWidth, Sizes.ListArrowRightHeight, arrow, ScaleMode.AspectFit);
 			}
 
 			tk.LineWidth = 0;
 			tk.FillColor = color;
-			tk.DrawCircle (new Point (countX1, countYC), StyleConf.ListCountRadio);
-			tk.DrawCircle (new Point (countX2, countYC), StyleConf.ListCountRadio);
-			tk.DrawRectangle (new Point (countX1, countY), StyleConf.ListCountWidth, 2 * StyleConf.ListCountRadio);
+			tk.DrawCircle (new Point (countX1, countYC), Sizes.ListCountRadio);
+			tk.DrawCircle (new Point (countX2, countYC), Sizes.ListCountRadio);
+			tk.DrawRectangle (new Point (countX1, countY), Sizes.ListCountWidth, 2 * Sizes.ListCountRadio);
 			tk.StrokeColor = App.Current.Style.ThemeBase;
 			tk.FontAlignment = FontAlignment.Center;
 			tk.FontWeight = FontWeight.Bold;
 			tk.FontSize = 14;
-			tk.DrawText (new Point (countX1, countY), StyleConf.ListCountWidth,
-				2 * StyleConf.ListCountRadio, count.ToString ());
+			tk.DrawText (new Point (countX1, countY), Sizes.ListCountWidth,
+						 2 * Sizes.ListCountRadio, count.ToString ());
 		}
 
 		static void RenderPlayButton (IDrawingToolkit tk, Area cellArea, bool insensitive, CellState state)
@@ -202,7 +204,7 @@ namespace LongoMatch.Drawing
 
 			/* Text */
 			tk.StrokeColor = textColor;
-			tk.FontSize = StyleConf.ListTextFontSize;
+			tk.FontSize = Sizes.ListTextFontSize;
 			tk.FontWeight = FontWeight.Bold;
 			tk.FontAlignment = FontAlignment.Left;
 			tk.DrawText (textP, textW, backgroundArea.Height, text);
@@ -214,8 +216,8 @@ namespace LongoMatch.Drawing
 			Point image, text;
 			double textWidth;
 
-			image = new Point (StyleConf.ListTextOffset, cellArea.Start.Y);
-			text = new Point (image.X + StyleConf.ListRowSeparator + StyleConf.ListImageWidth,
+			image = new Point (Sizes.ListTextOffset, cellArea.Start.Y);
+			text = new Point (image.X + Sizes.ListRowSeparator + Sizes.ListImageWidth,
 				cellArea.Start.Y);
 			textWidth = cellArea.Start.X + cellArea.Width - text.X;
 
@@ -232,7 +234,7 @@ namespace LongoMatch.Drawing
 		public static void RenderPlaylist (Playlist playlist, int count, bool isExpanded, IDrawingToolkit tk,
 										   IContext context, Area backgroundArea, Area cellArea)
 		{
-			Point textP = new Point (StyleConf.ListTextOffset, cellArea.Start.Y);
+			Point textP = new Point (Sizes.ListTextOffset, cellArea.Start.Y);
 			tk.Context = context;
 			tk.Begin ();
 			RenderBackgroundAndText (isExpanded, tk, backgroundArea, textP, cellArea.Width - textP.X, playlist.Name);
@@ -242,9 +244,9 @@ namespace LongoMatch.Drawing
 		}
 
 		public static void RenderAnalysisCategory (EventTypeTimelineVM vm, int count, bool isExpanded, IDrawingToolkit tk,
-		                                           IContext context, Area backgroundArea, Area cellArea, CellState state)
+												   IContext context, Area backgroundArea, Area cellArea, CellState state)
 		{
-			Point textP = new Point (StyleConf.ListTextOffset, cellArea.Start.Y);
+			Point textP = new Point (Sizes.ListTextOffset, cellArea.Start.Y);
 			tk.Context = context;
 			tk.Begin ();
 			RenderBackgroundAndText (isExpanded, tk, backgroundArea, textP, cellArea.Width - textP.X, vm.EventTypeVM.Name);
@@ -260,7 +262,7 @@ namespace LongoMatch.Drawing
 		public static void RenderAnalysisCategory (EventType cat, int count, bool isExpanded, IDrawingToolkit tk,
 												   IContext context, Area backgroundArea, Area cellArea)
 		{
-			Point textP = new Point (StyleConf.ListTextOffset, cellArea.Start.Y);
+			Point textP = new Point (Sizes.ListTextOffset, cellArea.Start.Y);
 			tk.Context = context;
 			tk.Begin ();
 			RenderBackgroundAndText (isExpanded, tk, backgroundArea, textP, cellArea.Width - textP.X, cat.Name);
@@ -275,10 +277,10 @@ namespace LongoMatch.Drawing
 											 out Point circlePoint, out double textWidth)
 		{
 			selectPoint = new Point (backgroundArea.Start.X, backgroundArea.Start.Y);
-			textPoint = new Point (selectPoint.X + StyleConf.ListSelectedWidth + StyleConf.ListRowSeparator, selectPoint.Y);
-			imagePoint = new Point (textPoint.X + StyleConf.ListTextWidth + StyleConf.ListRowSeparator, selectPoint.Y);
-			textWidth = StyleConf.ListTextWidth;
-			circlePoint = new Point (selectPoint.X + StyleConf.ListSelectedWidth / 2, selectPoint.Y + backgroundArea.Height / 2);
+			textPoint = new Point (selectPoint.X + Sizes.ListSelectedWidth + Sizes.ListRowSeparator, selectPoint.Y);
+			imagePoint = new Point (textPoint.X + Sizes.ListTextWidth + Sizes.ListRowSeparator, selectPoint.Y);
+			textWidth = Sizes.ListTextWidth;
+			circlePoint = new Point (selectPoint.X + Sizes.ListSelectedWidth / 2, selectPoint.Y + backgroundArea.Height / 2);
 
 			tk.LineWidth = 0;
 			if (state.HasFlag (CellState.Prelit)) {
@@ -290,13 +292,13 @@ namespace LongoMatch.Drawing
 			/* Selection rectangle */
 			tk.LineWidth = 0;
 			tk.FillColor = color;
-			tk.DrawRectangle (selectPoint, StyleConf.ListSelectedWidth, backgroundArea.Height);
+			tk.DrawRectangle (selectPoint, Sizes.ListSelectedWidth, backgroundArea.Height);
 			tk.FillColor = App.Current.Style.ThemeBase;
-			tk.DrawCircle (circlePoint, (StyleConf.ListSelectedWidth / 2) - 1);
+			tk.DrawCircle (circlePoint, (Sizes.ListSelectedWidth / 2) - 1);
 			if (state.HasFlag (CellState.Selected)) {
 				tk.FillColor = App.Current.Style.ScreenBase;
 				tk.FillColor = App.Current.Style.ThemeContrastDisabled;
-				tk.DrawCircle (circlePoint, (StyleConf.ListSelectedWidth / 2) - 2);
+				tk.DrawCircle (circlePoint, (Sizes.ListSelectedWidth / 2) - 2);
 			}
 
 			if (desc != null) {
@@ -308,12 +310,13 @@ namespace LongoMatch.Drawing
 			}
 			if (selected) {
 				if (EyeSurface == null) {
-					EyeSurface = App.Current.DrawingToolkit.CreateSurfaceFromResource (StyleConf.ListEyeIconPath, false);
+					EyeSurface = App.Current.DrawingToolkit.CreateSurfaceFromIcon (Icons.ListEyePath, false);
 				}
-				tk.DrawSurface (new Point (imagePoint.X - EyeSurface.Width - StyleConf.ListEyeIconOffset, imagePoint.Y + backgroundArea.Height / 2 - EyeSurface.Height / 2), StyleConf.ListEyeIconWidth, StyleConf.ListEyeIconHeight, EyeSurface, ScaleMode.AspectFit);
+				tk.DrawSurface (new Point (imagePoint.X - EyeSurface.Width - Sizes.ListEyeIconOffset, imagePoint.Y + backgroundArea.Height / 2 - EyeSurface.Height / 2),
+								Sizes.ListEyeIconWidth, Sizes.ListEyeIconHeight, EyeSurface, ScaleMode.AspectFit);
 			}
 			if (ss != null) {
-				tk.DrawImage (imagePoint, StyleConf.ListImageWidth, cellArea.Height, ss,
+				tk.DrawImage (imagePoint, Sizes.ListImageWidth, cellArea.Height, ss,
 					ScaleMode.AspectFit);
 			}
 		}
@@ -327,7 +330,7 @@ namespace LongoMatch.Drawing
 			double textWidth;
 
 			if (subsImage == null) {
-				subsImage = App.Current.ResourcesLocator.LoadImage (StyleConf.SubsIcon);
+				subsImage = App.Current.ResourcesLocator.LoadIcon (Icons.Subs);
 			}
 			tk.Context = context;
 			tk.Begin ();
@@ -335,13 +338,13 @@ namespace LongoMatch.Drawing
 			RenderTimelineEventBase (color, null, selected, null, tk, context, backgroundArea, cellArea, state,
 				out selectPoint, out textPoint, out imagePoint, out circlePoint, out textWidth);
 			inPoint = textPoint;
-			imgPoint = new Point (textPoint.X + StyleConf.ListImageWidth + StyleConf.ListRowSeparator, textPoint.Y);
-			outPoint = new Point (imgPoint.X + 20 + StyleConf.ListRowSeparator, imgPoint.Y);
+			imgPoint = new Point (textPoint.X + Sizes.ListImageWidth + Sizes.ListRowSeparator, textPoint.Y);
+			outPoint = new Point (imgPoint.X + 20 + Sizes.ListRowSeparator, imgPoint.Y);
 			RenderPlayer (tk, playerIn, inPoint);
 			tk.DrawImage (imgPoint, 20, cellArea.Height, subsImage, ScaleMode.AspectFit);
 			RenderPlayer (tk, playerOut, outPoint);
 
-			timePoint = new Point (outPoint.X + StyleConf.ListImageWidth + StyleConf.ListRowSeparator, textPoint.Y);
+			timePoint = new Point (outPoint.X + Sizes.ListImageWidth + Sizes.ListRowSeparator, textPoint.Y);
 			tk.FontSize = 10;
 			tk.FontWeight = FontWeight.Normal;
 			tk.StrokeColor = App.Current.Style.TextBase;
@@ -364,17 +367,17 @@ namespace LongoMatch.Drawing
 			RenderTimelineEventBase (color, ss, selected, desc, tk, context, backgroundArea, cellArea, state,
 				out selectPoint, out textPoint, out imagePoint, out circlePoint, out textWidth);
 
-			imagePoint.X += StyleConf.ListImageWidth + StyleConf.ListRowSeparator;
+			imagePoint.X += Sizes.ListImageWidth + Sizes.ListRowSeparator;
 			if (players != null && players.Count > 0) {
 				foreach (LMPlayer p in players) {
 					RenderPlayer (tk, p, imagePoint);
-					imagePoint.X += StyleConf.ListImageWidth + StyleConf.ListRowSeparator;
+					imagePoint.X += Sizes.ListImageWidth + Sizes.ListRowSeparator;
 				}
 			}
 			if (teams != null) {
 				foreach (var team in teams) {
 					RenderTeam (tk, team, imagePoint);
-					imagePoint.X += StyleConf.ListImageWidth + StyleConf.ListRowSeparator;
+					imagePoint.X += Sizes.ListImageWidth + Sizes.ListRowSeparator;
 				}
 			}
 			RenderSeparationLine (tk, context, backgroundArea);

--- a/LongoMatch.Drawing/Widgets/CamerasLabelsView.cs
+++ b/LongoMatch.Drawing/Widgets/CamerasLabelsView.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using VAS.Core;
 using VAS.Core.Common;
 using VAS.Core.Interfaces.Drawing;
+using VAS.Core.Resources.Styles;
 using VAS.Core.ViewModel;
 using VAS.Drawing;
 using VAS.Drawing.CanvasObjects.Timeline;
@@ -84,8 +85,8 @@ namespace LongoMatch.Drawing.Widgets
 		{
 			int row = 0, w, h, height = 0;
 
-			w = StyleConf.TimelineLabelsWidth * 2;
-			h = StyleConf.TimelineCameraHeight;
+			w = Sizes.TimelineLabelsWidth * 2;
+			h = Sizes.TimelineCameraHeight;
 
 			// Main camera
 			AddCamera (fileSetVM.ViewModels [0], w, h, ref row);

--- a/LongoMatch.Drawing/Widgets/CamerasTimelineView.cs
+++ b/LongoMatch.Drawing/Widgets/CamerasTimelineView.cs
@@ -25,6 +25,7 @@ using VAS.Core.Handlers;
 using VAS.Core.Interfaces.Drawing;
 using VAS.Core.Store;
 using VAS.Core.Store.Drawables;
+using VAS.Core.Resources.Styles;
 using VAS.Core.ViewModel;
 using VAS.Drawing;
 using VAS.Drawing.CanvasObjects.Timeline;
@@ -132,7 +133,7 @@ namespace LongoMatch.Drawing.Widgets
 			if (ViewModel == null)
 				return;
 
-			double width = ViewModel.Project.FileSet.Duration.TotalSeconds / SecondsPerPixel + StyleConf.TimelinePadding;
+			double width = ViewModel.Project.FileSet.Duration.TotalSeconds / SecondsPerPixel + Sizes.TimelinePadding;
 			foreach (TimelineView tl in timelines) {
 				tl.Width = width;
 				tl.SecondsPerPixel = SecondsPerPixel;
@@ -156,7 +157,7 @@ namespace LongoMatch.Drawing.Widgets
 				ShowLine = true,
 				Duration = ViewModel.Project.FileSet.Duration,
 				DraggingMode = NodeDraggingMode.All,
-				Height = StyleConf.TimelineCameraHeight,
+				Height = Sizes.TimelineCameraHeight,
 				OffsetY = 0,
 				LineColor = App.Current.Style.ThemeContrastDisabled,
 				BackgroundColor = App.Current.Style.ScreenBase
@@ -172,8 +173,8 @@ namespace LongoMatch.Drawing.Widgets
 				CameraTimelineView cameraTimeLine = new CameraTimelineView {
 					ShowName = false,
 					ShowLine = true,
-					Height = StyleConf.TimelineCameraHeight,
-					OffsetY = i * StyleConf.TimelineCameraHeight,
+					Height = Sizes.TimelineCameraHeight,
+					OffsetY = i * Sizes.TimelineCameraHeight,
 					LineColor = App.Current.Style.ThemeContrastDisabled,
 					BackgroundColor = App.Current.Style.ScreenBase,
 				};

--- a/LongoMatch.Drawing/Widgets/LMPlaysTimeline.cs
+++ b/LongoMatch.Drawing/Widgets/LMPlaysTimeline.cs
@@ -23,6 +23,7 @@ using VAS.Core.Common;
 using VAS.Core.Handlers;
 using VAS.Core.Interfaces.Drawing;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.Core.ViewModel;
 using VAS.Drawing.CanvasObjects.Timeline;
 using VAS.Drawing.Widgets;
@@ -86,8 +87,8 @@ namespace LongoMatch.Drawing.Widgets
 			var timeline = new PeriodsTimelineView {
 				DraggingMode = NodeDraggingMode.All,
 				Duration = ViewModel.Project.FileSet.Duration,
-				Height = StyleConf.TimelineCategoryHeight,
-				OffsetY = line * StyleConf.TimelineCategoryHeight,
+				Height = Sizes.TimelineCategoryHeight,
+				OffsetY = line * Sizes.TimelineCategoryHeight,
 				LineColor = App.Current.Style.ThemeBase,
 				BackgroundColor = VASDrawing.Utils.ColorForRow (line),
 				ShowLine = false

--- a/LongoMatch.Drawing/Widgets/LMProjectCardCanvasView.cs
+++ b/LongoMatch.Drawing/Widgets/LMProjectCardCanvasView.cs
@@ -6,6 +6,7 @@ using System;
 using LongoMatch.Core.ViewModel;
 using VAS.Core.Common;
 using VAS.Core.Interfaces.Drawing;
+using VAS.Core.Resources;
 using VAS.Drawing.Widgets;
 
 namespace LongoMatch.Drawing.Widgets
@@ -34,15 +35,15 @@ namespace LongoMatch.Drawing.Widgets
 
 		Color scoreBoxColor;
 
-		protected override void DisposeManagedResources()
+		protected override void DisposeManagedResources ()
 		{
-			base.DisposeManagedResources();
+			base.DisposeManagedResources ();
 			ViewModel = null;
 		}
 
 		static LMProjectCardCanvasView ()
 		{
-			stopwatch = App.Current.DrawingToolkit.CreateSurfaceFromIcon (StyleConf.StopwatchIcon);
+			stopwatch = App.Current.DrawingToolkit.CreateSurfaceFromIcon (Icons.Stopwatch);
 		}
 
 		public LMProjectCardCanvasView ()

--- a/LongoMatch.Drawing/Widgets/LMTimelineLabels.cs
+++ b/LongoMatch.Drawing/Widgets/LMTimelineLabels.cs
@@ -21,6 +21,7 @@ using VAS.Core;
 using VAS.Core.Common;
 using VAS.Core.Interfaces.Drawing;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.Drawing.CanvasObjects.Timeline;
 using VAS.Drawing.Widgets;
 using VUtils = VAS.Drawing.Utils;
@@ -33,8 +34,8 @@ namespace LongoMatch.Drawing.Widgets
 	{
 		public LMTimelineLabels (IWidget widget) : base (widget)
 		{
-			labelWidth = StyleConf.TimelineLabelsWidth;
-			labelHeight = StyleConf.TimelineSelectionLeftHeight;
+			labelWidth = Sizes.TimelineLabelsWidth;
+			labelHeight = Sizes.TimelineSelectionLeftHeight;
 		}
 
 		public LMTimelineLabels () : this (null)

--- a/LongoMatch.GUI/Gui/Component/DashboardWidget.cs
+++ b/LongoMatch.GUI/Gui/Component/DashboardWidget.cs
@@ -30,6 +30,7 @@ using VAS.Core.Events;
 using VAS.Core.Handlers;
 using VAS.Core.Interfaces.MVVMC;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.Core.Store;
 using VAS.Core.Store.Templates;
 using VAS.Core.ViewModel;
@@ -61,7 +62,7 @@ namespace LongoMatch.Gui.Component
 		{
 			this.Build ();
 
-			applyimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-apply", StyleConf.ButtonDialogIconSize);
+			applyimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-apply", Sizes.ButtonDialogIconSize);
 
 			tagger = new DashboardCanvas (new WidgetWrapper (drawingarea));
 			tagger.ShowMenuEvent += HandleShowMenuEvent;

--- a/LongoMatch.GUI/Gui/Component/EventsListWidget.cs
+++ b/LongoMatch.GUI/Gui/Component/EventsListWidget.cs
@@ -21,6 +21,7 @@ using LongoMatch.Core.ViewModel;
 using VAS.Core;
 using VAS.Core.Common;
 using VAS.Core.Interfaces.MVVMC;
+using VAS.Core.Resources.Styles;
 using Helpers = VAS.UI.Helpers;
 
 namespace LongoMatch.Gui.Component
@@ -37,7 +38,7 @@ namespace LongoMatch.Gui.Component
 		{
 			this.Build ();
 			playsnotebook.Page = 0;
-			playsList1.HeightRequest = StyleConf.PlayerCapturerControlsHeight;
+			playsList1.HeightRequest = Sizes.PlayerCapturerControlsHeight;
 
 			playsList = new LMTimelineEventsTreeView ();
 			playsList.Show ();

--- a/LongoMatch.GUI/Gui/Component/PlayListWidget.cs
+++ b/LongoMatch.GUI/Gui/Component/PlayListWidget.cs
@@ -22,6 +22,7 @@ using VAS.Core;
 using VAS.Core.Common;
 using VAS.Core.Events;
 using VAS.Core.Interfaces.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.Core.ViewModel;
 using VAS.UI.Helpers;
 using Misc = VAS.UI.Helpers.Misc;
@@ -54,8 +55,8 @@ namespace LongoMatch.Gui.Component
 			newbutton.CanFocus = false;
 			newvideobutton.CanFocus = false;
 
-			hbox2.HeightRequest = StyleConf.PlayerCapturerControlsHeight;
-			recimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-control-record", StyleConf.PlayerCapturerIconSize);
+			hbox2.HeightRequest = Sizes.PlayerCapturerControlsHeight;
+			recimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-control-record", Sizes.PlayerCapturerIconSize);
 			newvideobutton.Clicked += HandleRenderPlaylistClicked;
 
 			Bind ();
@@ -81,7 +82,7 @@ namespace LongoMatch.Gui.Component
 		{
 			ctx = this.GetBindingContext ();
 			ctx.Add (newbutton.BindWithIcon (
-				App.Current.ResourcesLocator.LoadIcon ("lm-playlist-new", StyleConf.PlayerCapturerIconSize),
+				App.Current.ResourcesLocator.LoadIcon ("lm-playlist-new", Sizes.PlayerCapturerIconSize),
 				vm => ((PlaylistCollectionVM)vm).NewCommand));
 		}
 

--- a/LongoMatch.GUI/Gui/Component/PlaysSelectionWidget.cs
+++ b/LongoMatch.GUI/Gui/Component/PlaysSelectionWidget.cs
@@ -21,6 +21,7 @@ using LongoMatch.Core.ViewModel;
 using VAS.Core;
 using VAS.Core.Common;
 using VAS.Core.Interfaces.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.UI.Helpers;
 using Helpers = VAS.UI.Helpers;
 
@@ -156,10 +157,10 @@ namespace LongoMatch.Gui.Component
 			s1.Add (categoriesfilter);
 			s2.Add (playersfilter);
 			l = new Gtk.Label (Catalog.GetString ("Categories filter"));
-			l.HeightRequest = StyleConf.PlayerCapturerControlsHeight;
+			l.HeightRequest = Sizes.PlayerCapturerControlsHeight;
 			filtersnotebook.AppendPage (s1, l);
 			l = new Gtk.Label (Catalog.GetString ("Players filter"));
-			l.HeightRequest = StyleConf.PlayerCapturerControlsHeight;
+			l.HeightRequest = Sizes.PlayerCapturerControlsHeight;
 			filtersnotebook.AppendPage (s2, l);
 			filtersnotebook.ShowAll ();
 		}

--- a/LongoMatch.GUI/Gui/Component/ProjectsIconWidget.cs
+++ b/LongoMatch.GUI/Gui/Component/ProjectsIconWidget.cs
@@ -27,6 +27,7 @@ using LongoMatch.Core.Handlers;
 using LongoMatch.Core.Store;
 using VAS.Core;
 using VAS.Core.Common;
+using VAS.Core.Resources.Styles;
 using VAS.Core.Store;
 using VAS.Core.ViewModel;
 using Misc = VAS.UI.Helpers.Misc;
@@ -236,7 +237,7 @@ namespace LongoMatch.Gui.Component
 
 			TreeViewColumn filterColumn = new TreeViewColumn ();
 			checkCell = new CellRendererToggle ();
-			checkCell.Width = StyleConf.FilterTreeViewToogleWidth;
+			checkCell.Width = Sizes.FilterTreeViewToogleWidth;
 			checkCell.Toggled += HandleCellToggled;
 			filterColumn.PackStart (checkCell, false);
 			filterColumn.AddAttribute (checkCell, "active", COL_ACTIVE);

--- a/LongoMatch.GUI/Gui/Component/SynchronizationWidget.cs
+++ b/LongoMatch.GUI/Gui/Component/SynchronizationWidget.cs
@@ -24,6 +24,7 @@ using VAS.Core.Common;
 using VAS.Core.Hotkeys;
 using VAS.Core.Interfaces.GUI;
 using VAS.Core.Interfaces.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.Core.Store;
 using VAS.Core.ViewModel;
 using VAS.Drawing.Cairo;
@@ -65,9 +66,9 @@ namespace LongoMatch.Gui.Component
 			camerasLabels = new CamerasLabelsView (new WidgetWrapper (labelsarea));
 
 			// Set some sane defaults
-			labels_vbox.WidthRequest = StyleConf.TimelineLabelsWidth;
+			labels_vbox.WidthRequest = Sizes.TimelineLabelsWidth;
 			// We need to align the timerule and the beginning of labels list
-			timerulearea.HeightRequest = StyleConf.TimelineCameraHeight;
+			timerulearea.HeightRequest = Sizes.TimelineCameraHeight;
 
 			menu = new PeriodsMenu ();
 

--- a/LongoMatch.GUI/Gui/Component/TeamTemplateEditor.cs
+++ b/LongoMatch.GUI/Gui/Component/TeamTemplateEditor.cs
@@ -27,6 +27,7 @@ using VAS.Core;
 using VAS.Core.Common;
 using VAS.Core.Events;
 using VAS.Core.Interfaces.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.Drawing.Cairo;
 using VAS.UI.UI.Component;
 using Color = VAS.Core.Common.Color;
@@ -55,7 +56,7 @@ namespace LongoMatch.Gui.Component
 		{
 			this.Build ();
 
-			applyimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-apply", StyleConf.ButtonDialogIconSize);
+			applyimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-apply", Sizes.ButtonDialogIconSize);
 
 			teamtagger = new LMTeamTaggerView (new WidgetWrapper (drawingarea));
 			shieldvbox.WidthRequest = SHIELD_SIZE;

--- a/LongoMatch.GUI/Gui/Component/TeamsComboBox.cs
+++ b/LongoMatch.GUI/Gui/Component/TeamsComboBox.cs
@@ -20,6 +20,7 @@ using Gdk;
 using Gtk;
 using LongoMatch.Core.Store.Templates;
 using VAS.Core.Common;
+using VAS.Core.Resources.Styles;
 using Helpers = VAS.UI.Helpers;
 using Image = VAS.Core.Common.Image;
 using VAS.Core;
@@ -39,10 +40,10 @@ namespace LongoMatch.Gui.Component
 		{
 			Clear ();
 			imageRenderer = new CellRendererImage ();
-			imageRenderer.Width = StyleConf.NewTeamsIconSize;
-			imageRenderer.Height = StyleConf.NewTeamsIconSize;
+			imageRenderer.Width = Sizes.NewTeamsIconSize;
+			imageRenderer.Height = Sizes.NewTeamsIconSize;
 			texrender = new CellRendererText ();
-			texrender.Font = App.Current.Style.Font + " " + StyleConf.NewTeamsFontSize;
+			texrender.Font = App.Current.Style.Font + " " + Sizes.NewTeamsFontSize;
 			texrender.Alignment = Pango.Alignment.Center;
 
 			if (Direction == TextDirection.Ltr) {
@@ -58,7 +59,7 @@ namespace LongoMatch.Gui.Component
 				Image shield;
 
 				if (t.Shield == null) {
-					shield = App.Current.ResourcesLocator.LoadIcon ("vas-default-shield", StyleConf.NewTeamsIconSize);
+					shield = App.Current.ResourcesLocator.LoadIcon ("vas-default-shield", Sizes.NewTeamsIconSize);
 				} else {
 					shield = t.Shield;
 				}

--- a/LongoMatch.GUI/Gui/Dialog/VideoConversionTool.cs
+++ b/LongoMatch.GUI/Gui/Dialog/VideoConversionTool.cs
@@ -24,6 +24,7 @@ using LongoMatch.Gui.Component;
 using VAS.Core;
 using VAS.Core.Common;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.Core.Store;
 using VAS.Core.ViewModel;
 using VAS.UI.Helpers;
@@ -56,7 +57,7 @@ namespace LongoMatch.Gui.Dialog
 			FillBitrates ();
 			addbutton1.Clicked += OnAddbuttonClicked;
 			convertimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-video-converter-big", 64);
-			addimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-add", StyleConf.ButtonNormalSize);
+			addimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-add", Sizes.ButtonNormalSize);
 			eventbox1.ModifyBg (StateType.Normal, Misc.ToGdkColor (App.Current.Style.ThemeBase));
 			addbutton1.CanFocus = false;
 			scrolledwindow1.Visible = false;

--- a/LongoMatch.GUI/Gui/Panel/NewProjectPanel.cs
+++ b/LongoMatch.GUI/Gui/Panel/NewProjectPanel.cs
@@ -32,6 +32,7 @@ using VAS.Core.Hotkeys;
 using VAS.Core.Interfaces.GUI;
 using VAS.Core.Interfaces.Multimedia;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.Core.Store;
 using VAS.Core.Store.Templates;
 using VAS.Drawing.Cairo;
@@ -186,13 +187,13 @@ namespace LongoMatch.Gui.Panel
 			grp.AddWidget (lefttable);
 			grp.AddWidget (righttable);
 
-			centerbox.WidthRequest = StyleConf.NewTeamsComboWidth * 2 + StyleConf.NewTeamsSpacing;
+			centerbox.WidthRequest = Sizes.NewTeamsComboWidth * 2 + Sizes.NewTeamsSpacing;
 			lefttable.RowSpacing = outputfiletable.RowSpacing =
-				righttable.RowSpacing = StyleConf.NewTableHSpacing;
-			lefttable.ColumnSpacing = righttable.ColumnSpacing = StyleConf.NewTableHSpacing;
-			vsimage.WidthRequest = StyleConf.NewTeamsSpacing;
-			hometeamscombobox.WidthRequest = awayteamscombobox.WidthRequest = StyleConf.NewTeamsComboWidth;
-			hometeamscombobox.HeightRequest = awayteamscombobox.HeightRequest = StyleConf.NewTeamsComboHeight;
+				righttable.RowSpacing = Sizes.NewTableHSpacing;
+			lefttable.ColumnSpacing = righttable.ColumnSpacing = Sizes.NewTableHSpacing;
+			vsimage.WidthRequest = Sizes.NewTeamsSpacing;
+			hometeamscombobox.WidthRequest = awayteamscombobox.WidthRequest = Sizes.NewTeamsComboWidth;
+			hometeamscombobox.HeightRequest = awayteamscombobox.HeightRequest = Sizes.NewTeamsComboHeight;
 			hometeamscombobox.WrapWidth = awayteamscombobox.WrapWidth = 1;
 			homealignment.Xscale = awayalignment.Xscale = 0;
 			homealignment.Xalign = 0.8f;
@@ -201,10 +202,10 @@ namespace LongoMatch.Gui.Panel
 
 		void LoadIcons ()
 		{
-			fileimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-video-file", StyleConf.ProjectTypeIconSize);
-			captureimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-video-device", StyleConf.ProjectTypeIconSize);
-			fakeimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-video-device-fake", StyleConf.ProjectTypeIconSize);
-			ipimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-video-device-ip", StyleConf.ProjectTypeIconSize);
+			fileimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-video-file", Sizes.ProjectTypeIconSize);
+			captureimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-video-device", Sizes.ProjectTypeIconSize);
+			fakeimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-video-device-fake", Sizes.ProjectTypeIconSize);
+			ipimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-video-device-ip", Sizes.ProjectTypeIconSize);
 			vsimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-vs", 50);
 
 			filebutton.Clicked += HandleProjectTypeSet;

--- a/LongoMatch.GUI/Gui/Panel/PanelHeader.cs
+++ b/LongoMatch.GUI/Gui/Panel/PanelHeader.cs
@@ -18,6 +18,7 @@
 using System;
 using Gtk;
 using VAS.Core.Common;
+using VAS.Core.Resources.Styles;
 using Helpers = VAS.UI.Helpers;
 
 namespace LongoMatch.Gui.Panel
@@ -45,13 +46,13 @@ namespace LongoMatch.Gui.Panel
 			logoimage.Image = App.Current.ResourcesLocator.LoadIcon (App.Current.SoftwareIconName, 45);
 			backrectbuttonimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-back", 40);
 			applyroundedbuttonimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-apply", 40);
-			headerhbox.HeightRequest = StyleConf.HeaderHeight;
+			headerhbox.HeightRequest = Sizes.HeaderHeight;
 		}
 
 		public string Title {
 			set {
 				titlelabel.Markup = String.Format ("<span font_desc=\"{0}\"><b>{1}</b></span>",
-					StyleConf.HeaderFontSize, value);
+					Sizes.HeaderFontSize, value);
 			}
 		}
 

--- a/LongoMatch.GUI/Gui/Panel/SportsTemplatesPanel.cs
+++ b/LongoMatch.GUI/Gui/Panel/SportsTemplatesPanel.cs
@@ -28,6 +28,7 @@ using VAS.Core.Common;
 using VAS.Core.Hotkeys;
 using VAS.Core.Interfaces.GUI;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.UI.Helpers.Bindings;
 using Image = VAS.Core.Common.Image;
 using Helpers = VAS.UI.Helpers;
@@ -58,10 +59,10 @@ namespace LongoMatch.Gui.Panel
 			panelheader1.Title = Title;
 			panelheader1.BackClicked += (sender, e) => App.Current.StateController.MoveBack ();
 
-			templateimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-template-header", StyleConf.TemplatesHeaderIconSize);
-			categoryheaderimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-category-header", StyleConf.TemplatesHeaderIconSize);
+			templateimage.Image = App.Current.ResourcesLocator.LoadIcon ("vas-template-header", Sizes.TemplatesHeaderIconSize);
+			categoryheaderimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-category-header", Sizes.TemplatesHeaderIconSize);
 			// FIXME: "vertical-separator" has a png extension
-			vseparatorimage.Image = new Image (Helpers.Misc.LoadIcon ("lm-vertical-separator", StyleConf.TemplatesIconSize));
+			vseparatorimage.Image = new Image (Helpers.Misc.LoadIcon ("lm-vertical-separator", Sizes.TemplatesIconSize));
 
 			// Connect buttons from the bar
 			newtemplatebutton.Entered += HandleEnterTemplateButton;
@@ -180,19 +181,19 @@ namespace LongoMatch.Gui.Panel
 		{
 			ctx = this.GetBindingContext ();
 			ctx.Add (addcategorybutton.BindWithIcon (
-				App.Current.ResourcesLocator.LoadIcon ("lm-tag-category", StyleConf.TemplatesIconSize),
+				App.Current.ResourcesLocator.LoadIcon ("lm-tag-category", Sizes.TemplatesIconSize),
 				vm => ((DashboardsManagerVM)vm).AddButton, "Category"));
 			ctx.Add (scorebutton.BindWithIcon (
-				App.Current.ResourcesLocator.LoadIcon ("lm-tag-score", StyleConf.TemplatesIconSize),
+				App.Current.ResourcesLocator.LoadIcon ("lm-tag-score", Sizes.TemplatesIconSize),
 				vm => ((DashboardsManagerVM)vm).AddButton, "Score"));
 			ctx.Add (timerbutton.BindWithIcon (
-				App.Current.ResourcesLocator.LoadIcon ("lm-tag-timer", StyleConf.TemplatesIconSize),
+				App.Current.ResourcesLocator.LoadIcon ("lm-tag-timer", Sizes.TemplatesIconSize),
 				vm => ((DashboardsManagerVM)vm).AddButton, "Timer"));
 			ctx.Add (addtagbutton1.BindWithIcon (
-				App.Current.ResourcesLocator.LoadIcon ("lm-tag-tag", StyleConf.TemplatesIconSize),
+				App.Current.ResourcesLocator.LoadIcon ("lm-tag-tag", Sizes.TemplatesIconSize),
 				vm => ((DashboardsManagerVM)vm).AddButton, "Tag"));
 			ctx.Add (cardbutton.BindWithIcon (
-				App.Current.ResourcesLocator.LoadIcon ("lm-tag-card", StyleConf.TemplatesIconSize),
+				App.Current.ResourcesLocator.LoadIcon ("lm-tag-card", Sizes.TemplatesIconSize),
 				vm => ((DashboardsManagerVM)vm).AddButton, "Card"));
 
 			ctx.Add (deletetemplatebutton.Bind (vm => ((DashboardsManagerVM)vm).DeleteCommand));

--- a/LongoMatch.GUI/Gui/Panel/TeamsTemplatesPanel.cs
+++ b/LongoMatch.GUI/Gui/Panel/TeamsTemplatesPanel.cs
@@ -30,6 +30,7 @@ using VAS.Core.Common;
 using VAS.Core.Hotkeys;
 using VAS.Core.Interfaces.GUI;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.Core.ViewModel;
 using VAS.UI.Component;
 using VAS.UI.Helpers.Bindings;
@@ -57,10 +58,10 @@ namespace LongoMatch.Gui.Panel
 			panelheader1.Title = Title;
 			panelheader1.BackClicked += (sender, e) => App.Current.StateController.MoveBack ();
 
-			teamimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-team-header", StyleConf.TemplatesHeaderIconSize);
-			playerheaderimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-player-header", StyleConf.TemplatesHeaderIconSize);
+			teamimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-team-header", Sizes.TemplatesHeaderIconSize);
+			playerheaderimage.Image = App.Current.ResourcesLocator.LoadIcon ("lm-player-header", Sizes.TemplatesHeaderIconSize);
 			// FIXME: "vertical-separator" has a png extension
-			vseparatorimage.Image = new Image (Helpers.Misc.LoadIcon ("lm-vertical-separator", StyleConf.TemplatesIconSize));
+			vseparatorimage.Image = new Image (Helpers.Misc.LoadIcon ("lm-vertical-separator", Sizes.TemplatesIconSize));
 
 
 			newteambutton.Entered += HandleEnterTeamButton;

--- a/LongoMatch.GUI/Gui/Panel/WelcomePanel.cs
+++ b/LongoMatch.GUI/Gui/Panel/WelcomePanel.cs
@@ -29,6 +29,7 @@ using VAS.Core.Common;
 using VAS.Core.Hotkeys;
 using VAS.Core.Interfaces.GUI;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.UI.Helpers;
 using VAS.UI.Helpers.Bindings;
 using Action = System.Action;
@@ -86,8 +87,8 @@ namespace LongoMatch.Gui.Panel
 			buttonWidgets = new List<Widget> ();
 			buttons = new List<WelcomeButton> (default_buttons);
 
-			hbox1.BorderWidth = StyleConf.WelcomeBorder;
-			vbox2.Spacing = StyleConf.WelcomeIconsVSpacing;
+			hbox1.BorderWidth = Sizes.WelcomeBorder;
+			vbox2.Spacing = Sizes.WelcomeIconsVSpacing;
 			label3.ModifyFont (Pango.FontDescription.FromString ("Ubuntu 12"));
 			preferencesbutton.Clicked += HandlePreferencesClicked;
 
@@ -98,7 +99,7 @@ namespace LongoMatch.Gui.Panel
 
 		uint NRows {
 			get {
-				return (uint)StyleConf.WelcomeIconsTotalRows;
+				return (uint)Sizes.WelcomeIconsTotalRows;
 			}
 		}
 
@@ -161,11 +162,11 @@ namespace LongoMatch.Gui.Panel
 
 			Gtk.Image prefImage = new Gtk.Image (
 									  Helpers.Misc.LoadIcon ("lm-preferences",
-										  StyleConf.WelcomeIconSize, 0));
+															 Sizes.WelcomeIconSize, 0));
 			preferencesbutton.Add (prefImage);
 
-			preferencesbutton.WidthRequest = StyleConf.WelcomeIconSize;
-			preferencesbutton.HeightRequest = StyleConf.WelcomeIconSize;
+			preferencesbutton.WidthRequest = Sizes.WelcomeIconSize;
+			preferencesbutton.HeightRequest = Sizes.WelcomeIconSize;
 
 			// Our logo
 			logoImage = new ImageView ();
@@ -185,7 +186,7 @@ namespace LongoMatch.Gui.Panel
 
 			for (int i = 0; i < NRows; i++) {
 				Alignment al = new Alignment (0.5F, 0.5F, 0, 0);
-				hboxList.Add (new HBox (true, StyleConf.WelcomeIconsHSpacing));
+				hboxList.Add (new HBox (true, Sizes.WelcomeIconsHSpacing));
 				al.Add (hboxList [i]);
 				vbox2.Add (al);
 			}
@@ -193,7 +194,7 @@ namespace LongoMatch.Gui.Panel
 			int hboxRow = 0;
 			for (uint i = 0; i < buttons.Count; i++) {
 				Widget b;
-				if (i >= StyleConf.WelcomeIconsFirstRow && hboxRow == 0) {
+				if (i >= Sizes.WelcomeIconsFirstRow && hboxRow == 0) {
 					hboxRow++;
 				}
 				b = CreateButton (buttons [(int)i]);
@@ -212,16 +213,16 @@ namespace LongoMatch.Gui.Panel
 			Label label;
 
 			if (b.Icon == null) {
-				image = new ImageView (App.Current.ResourcesLocator.LoadIcon (b.Name, StyleConf.WelcomeIconImageSize));
+				image = new ImageView (App.Current.ResourcesLocator.LoadIcon (b.Name, Sizes.WelcomeIconImageSize));
 			} else {
 				image = new ImageView (b.Icon);
 			}
-			image.SetSize (StyleConf.WelcomeIconImageSize, StyleConf.WelcomeIconImageSize);
+			image.SetSize (Sizes.WelcomeIconImageSize, Sizes.WelcomeIconImageSize);
 
 			button = new Button ();
 			button.Clicked += (sender, e) => b.Func ();
-			button.HeightRequest = StyleConf.WelcomeIconSize;
-			button.WidthRequest = StyleConf.WelcomeIconSize;
+			button.HeightRequest = Sizes.WelcomeIconSize;
+			button.WidthRequest = Sizes.WelcomeIconSize;
 			button.Add (image);
 			if (buttonWidgets.Count == 0) {
 				button.Realized += (sender, e) => button.GrabFocus ();
@@ -237,7 +238,7 @@ namespace LongoMatch.Gui.Panel
 			label.Justify = Justification.Center;
 			sizegroup.AddWidget (label);
 
-			box = new VBox (false, StyleConf.WelcomeIconsTextSpacing);
+			box = new VBox (false, Sizes.WelcomeIconsTextSpacing);
 			box.PackStart (alignment, false, false, 0);
 			box.PackStart (label, false, false, 0);
 

--- a/LongoMatch.GUI/Gui/TreeView/PlaysCellRenderer.cs
+++ b/LongoMatch.GUI/Gui/TreeView/PlaysCellRenderer.cs
@@ -22,6 +22,7 @@ using LongoMatch.Drawing;
 using VAS.Core.Common;
 using VAS.Core.Interfaces.Drawing;
 using VAS.Core.Interfaces.MVVMC;
+using VAS.Core.Resources.Styles;
 using VAS.Drawing.Cairo;
 using Point = VAS.Core.Common.Point;
 
@@ -75,14 +76,14 @@ namespace LongoMatch.Gui.Component
 		{
 			x_offset = 0;
 			y_offset = 0;
-			width = StyleConf.ListSelectedWidth + StyleConf.ListRowSeparator + StyleConf.ListTextWidth;
-			height = StyleConf.ListCategoryHeight;
+			width = Sizes.ListSelectedWidth + Sizes.ListRowSeparator + Sizes.ListTextWidth;
+			height = Sizes.ListCategoryHeight;
 			if (Item is LMTimelineEvent) {
 				LMTimelineEvent evt = Item as LMTimelineEvent;
 				if (evt.Miniature != null) {
-					width += StyleConf.ListImageWidth + StyleConf.ListRowSeparator;
+					width += Sizes.ListImageWidth + Sizes.ListRowSeparator;
 				}
-				width += (StyleConf.ListImageWidth + StyleConf.ListRowSeparator) * (evt.Players.Count + evt.Teams.Count);
+				width += (Sizes.ListImageWidth + Sizes.ListRowSeparator) * (evt.Players.Count + evt.Teams.Count);
 			}
 		}
 

--- a/LongoMatch.Services/ViewModel/DashboardsManagerVM.cs
+++ b/LongoMatch.Services/ViewModel/DashboardsManagerVM.cs
@@ -22,6 +22,7 @@ using VAS.Core.MVVMC;
 using VAS.Core.Store;
 using VAS.Core.Store.Templates;
 using VAS.Core.ViewModel;
+using VAS.Core.Resources.Styles;
 using VAS.Services.ViewModel;
 
 namespace LongoMatch.Services.ViewModel
@@ -33,11 +34,11 @@ namespace LongoMatch.Services.ViewModel
 		public DashboardsManagerVM ()
 		{
 			AddButton = LoadedTemplate.AddButton;
-			NewCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-add", StyleConf.TemplatesIconSize);
-			SaveCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-save", StyleConf.TemplatesIconSize);
-			DeleteCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-delete", StyleConf.TemplatesIconSize);
-			ExportCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("lm-export", StyleConf.TemplatesIconSize);
-			ImportCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-import", StyleConf.TemplatesIconSize);
+			NewCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-add", Sizes.TemplatesIconSize);
+			SaveCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-save", Sizes.TemplatesIconSize);
+			DeleteCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-delete", Sizes.TemplatesIconSize);
+			ExportCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("lm-export", Sizes.TemplatesIconSize);
+			ImportCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-import", Sizes.TemplatesIconSize);
 			if (LimitationChart != null) {
 				LimitationChart.Dispose ();
 				LimitationChart = null;

--- a/LongoMatch.Services/ViewModel/LMTeamEditorVM.cs
+++ b/LongoMatch.Services/ViewModel/LMTeamEditorVM.cs
@@ -9,6 +9,7 @@ using VAS.Core;
 using VAS.Core.Common;
 using VAS.Core.Events;
 using VAS.Core.MVVMC;
+using VAS.Core.Resources.Styles;
 
 namespace LongoMatch.Services.ViewModel
 {
@@ -21,8 +22,8 @@ namespace LongoMatch.Services.ViewModel
 		{
 			NewPlayerCommand = new AsyncCommand (CreatePlayer, () => Team.Model != null);
 			DeletePlayersCommand = new AsyncCommand (DeletePlayers, () => Team.Selection.Any ());
-			NewPlayerCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-add", StyleConf.TemplatesIconSize);
-			DeletePlayersCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-delete", StyleConf.TemplatesIconSize);
+			NewPlayerCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-add", Sizes.TemplatesIconSize);
+			DeletePlayersCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-delete", Sizes.TemplatesIconSize);
 		}
 
 		public LMTeamVM Team {

--- a/LongoMatch.Services/ViewModel/TeamsManagerVM.cs
+++ b/LongoMatch.Services/ViewModel/TeamsManagerVM.cs
@@ -21,6 +21,7 @@ using LongoMatch.Core.ViewModel;
 using LongoMatch.Services.Interfaces;
 using VAS.Core;
 using VAS.Core.Common;
+using VAS.Core.Resources.Styles;
 using VAS.Core.Store;
 using VAS.Core.Store.Templates;
 using VAS.Core.ViewModel;
@@ -38,11 +39,11 @@ namespace LongoMatch.Services.ViewModel
 		public TeamsManagerVM ()
 		{
 			LoadedTemplate = new LMTeamVM ();
-			NewCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-add", StyleConf.TemplatesIconSize);
-			SaveCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-save", StyleConf.TemplatesIconSize);
-			DeleteCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-delete", StyleConf.TemplatesIconSize);
-			ExportCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("lm-export", StyleConf.TemplatesIconSize);
-			ImportCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-import", StyleConf.TemplatesIconSize);
+			NewCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-add", Sizes.TemplatesIconSize);
+			SaveCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-save", Sizes.TemplatesIconSize);
+			DeleteCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-delete", Sizes.TemplatesIconSize);
+			ExportCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("lm-export", Sizes.TemplatesIconSize);
+			ImportCommand.Icon = App.Current.ResourcesLocator.LoadIcon ("vas-import", Sizes.TemplatesIconSize);
 			TeamTagger = new LMTeamTaggerVM ();
 			TeamTagger.HomeTeam = (LMTeamVM)LoadedTemplate;
 			TeamTagger.AwayTeam = null;


### PR DESCRIPTION
- Move icon/image/font/color/sizes/themes from StyleConf to its own classes under Resources namespace
- Use LoadIcon instead of LoadImage when required
- Use CreateSurfaceFromIcon instead of CreateResourceFromResource when required
- Fix tests and data folder structure (within the VAS test project) due to the new method for loading icons