### PR TITLE
LON-1249: Fix Multiple selection for Lineup and Substitution Events

### DIFF
--- a/LongoMatch.Core/Store/LMTimelineEvent.cs
+++ b/LongoMatch.Core/Store/LMTimelineEvent.cs
@@ -121,6 +121,10 @@ namespace LongoMatch.Core.Store
 	[Serializable]
 	public class LineupEvent : StatEvent
 	{
+		public LineupEvent ()
+		{
+			Deletable = false;
+		}
 		public List<LMPlayer> HomeStartingPlayers {
 			get;
 			set;

--- a/LongoMatch.GUI/Gui/Menu/SportsPlaysMenu.cs
+++ b/LongoMatch.GUI/Gui/Menu/SportsPlaysMenu.cs
@@ -67,6 +67,8 @@ namespace LongoMatch.Gui.Menus
 				isSubstitution = plays.FirstOrDefault () is SubstitutionEvent;
 			}
 
+			MenuHelpers.FillExportToVideoFileMenu (render, project, plays, Catalog.GetString ("Export to video file"));
+
 			if (isLineup || isSubstitution) {
 				edit.Visible = true;
 				del.Visible = isSubstitution;
@@ -78,8 +80,6 @@ namespace LongoMatch.Gui.Menus
 				drawings.Visible = this.plays.Count == 1 && this.plays.FirstOrDefault ().Drawings.Count > 0;
 				moveCat.Visible = del.Visible = addPLN.Visible = duplicate.Visible = this.plays.Any ();
 			}
-
-			MenuHelpers.FillExportToVideoFileMenu (render, project, plays, Catalog.GetString ("Export to video file"));
 
 			if (plays.Count () > 0) {
 				string label = String.Format ("{0} ({1})", Catalog.GetString ("Delete"), plays.Count ());

--- a/LongoMatch.GUI/Gui/TreeView/LMTimelineEventsTreeView.cs
+++ b/LongoMatch.GUI/Gui/TreeView/LMTimelineEventsTreeView.cs
@@ -158,6 +158,39 @@ namespace LongoMatch.Gui.Component
 			}
 		}
 
+		protected override bool SelectFunction (TreeSelection selection, TreeModel model, TreePath path, bool selected)
+		{
+			//FIXME: This logic could be done in the TreeViewBase by passing the different ViewModel Types that do not
+			// 	     support multiple selection, then this logic could be shared for all TreeViews that need some elements
+			//		 in the treeview to be selected alone.
+			TreePath [] selectedRows;
+
+			selectedRows = selection.GetSelectedRows ();
+			if (!selected && selectedRows.Length > 0) {
+				TimelineEventVM timelineEvent;
+
+				var firstSelected = GetViewModelAtPath (selectedRows [0]);
+				// No multiple selection for event types and substitution events
+				if (selectedRows.Length == 1) {
+					if (firstSelected is EventTypeTimelineVM) {
+						return false;
+					} else if ((timelineEvent = (firstSelected as TimelineEventVM)) != null &&
+					           timelineEvent.Model is StatEvent) {
+						return false;
+					}
+				}
+
+				var currentSelected = GetViewModelAtPath (path);
+				if (currentSelected is EventTypeTimelineVM || ((timelineEvent = (currentSelected as TimelineEventVM)) != null &&
+				                                               timelineEvent.Model is StatEvent)) {
+					return false;
+				}
+				return true;
+			}
+			// Always unselect
+			return true;
+		}
+
 		protected override int HandleSort (TreeModel model, TreeIter a, TreeIter b)
 		{
 			object objecta, objectb;

--- a/LongoMatch.Services/Controller/LMEventsController.cs
+++ b/LongoMatch.Services/Controller/LMEventsController.cs
@@ -19,6 +19,7 @@
 //
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using LongoMatch.Core.Common;
 using LongoMatch.Core.Events;

--- a/Tests/Controller/TestLMEventsController.cs
+++ b/Tests/Controller/TestLMEventsController.cs
@@ -145,5 +145,16 @@ namespace Tests.Controller
 			mockLimitationService.Verify (ls => ls.MoveToUpgradeDialog (VASCountLimitedObjects.TimelineEvents.ToString ()),
 			                              Times.Once);
 		}
+
+		[Test]
+		public void EventsDeletedEvent_DeleteAllEvents_LineupEventNotDeleted ()
+		{
+			App.Current.EventsBroker.Publish (new EventsDeletedEvent {
+				TimelineEvents = projectVM.Timeline.Model
+			});
+
+			Assert.AreEqual (1, projectVM.Timeline.Model.Count);
+			Assert.AreSame (projectVM.Model.Lineup, projectVM.Timeline.Model.FirstOrDefault ());
+		}
 	}
 }


### PR DESCRIPTION
-Fix Export to video file appearing on Lineup and Substitutions Events
-Override DeletePlays in LMEventsController to filter LineupEvents