### PR TITLE
Do not create a new MediaFileSet, just clone it and limit

### DIFF
--- a/LongoMatch.Services/State/ProjectAnalysisState.cs
+++ b/LongoMatch.Services/State/ProjectAnalysisState.cs
@@ -78,8 +78,10 @@ namespace LongoMatch.Services.State
 					ViewModel.VideoPlayer.OpenFileSet (project.FileSet);
 				} else {
 					MediaFileSetVM limitedSet = new MediaFileSetVM ();
-					limitedSet.Model = new MediaFileSet ();
-					limitedSet.Model.Add (project.FileSet.Model.First ());
+					var fileset = project.FileSet.Model.Clone ();
+					fileset.Clear ();
+					fileset.Add (project.FileSet.Model.First ());
+					limitedSet.Model = fileset;
 					ViewModel.VideoPlayer.OpenFileSet (limitedSet);
 				}
 			} catch (Exception ex) {

--- a/Tests/Integration/TestPostGameAnalysis.cs
+++ b/Tests/Integration/TestPostGameAnalysis.cs
@@ -264,9 +264,10 @@ namespace Tests.Integration
 				It.IsAny<string> (), It.IsAny<string []> ())).Returns (projectPath);
 			await App.Current.EventsBroker.Publish<ImportProjectEvent> (new ImportProjectEvent ());
 			Assert.AreEqual (2, App.Current.DatabaseManager.ActiveDB.Count<LMProject> ());
-			LMProject retrievedProject = App.Current.DatabaseManager.ActiveDB.RetrieveAll<LMProject> ().ToList () [1];
-			Assert.IsNotNull (retrievedProject);
-			Assert.AreNotEqual (retrievedProject.ID, p.ID);
+			LMProject importedProject = App.Current.DatabaseManager.ActiveDB.RetrieveAll<LMProject> ().
+			                                SortByCreationDate (true).ToList () [0];
+			Assert.IsNotNull (importedProject);
+			Assert.AreNotEqual (importedProject.ID, p.ID);
 			int eventsCount = p.Timeline.Count;
 
 			AddEvent (p, 2, 3000, 3050, 3025);


### PR DESCRIPTION
- This fixes having a Different MediaFileSet ID's in VideoPlayerController
and the Events, so when closing and event it was opening again the video file