### PR TITLE
Set the Model in the LMProjectVM every time we fill the project

### DIFF
--- a/LongoMatch.GUI/Gui/Panel/NewProjectPanel.cs
+++ b/LongoMatch.GUI/Gui/Panel/NewProjectPanel.cs
@@ -441,6 +441,7 @@ namespace LongoMatch.Gui.Panel
 			project.UpdateEventTypesAndTimers ();
 			project.ConsolidateDescription ();
 			project.ProjectType = projectType;
+			ViewModel.Project.Model = project;
 		}
 
 		bool CreateProject ()
@@ -478,8 +479,6 @@ namespace LongoMatch.Gui.Panel
 			project = new LMProject ();
 			project.Description = new ProjectDescription ();
 			FillProject ();
-			ViewModel.Project.Model = project;
-
 
 			encSettings = new EncodingSettings ();
 			captureSettings = new CaptureSettings ();


### PR DESCRIPTION
- this fixes a bug in SportsCode importer when we have a project already created
without a dashboard, and wasn't setting the DashboardVM Model